### PR TITLE
Fix issues for newer jetpack versions

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -13,7 +13,7 @@ def main():
 
     calibrator = Calibration(config, LOAD_DIR)
     input('Hit any key when you have the chessboard prepared')
-
+    calibrator.capture_images()
     calibrator.compute_calibration(True)
 
 if __name__ == '__main__':

--- a/environment.yml
+++ b/environment.yml
@@ -5,12 +5,12 @@ channels:
   - defaults
 dependencies:
   - python >=3.6
-  - cudatoolkit=10.0
-  - cudnn=7.6.5
-  - pytorch=1.2.0
-  - torchvision=0.4.0
+  - cudatoolkit>=10.0
+  - cudnn>=7.6.5
+  - pytorch>=1.2.0
+  - torchvision>=0.4.0
   - pip
   - pip:
       - opencv-python
       - numpy
-      - StereoVision=1.0.4
+      - StereoVision>=1.0.4

--- a/lib/calibration.py
+++ b/lib/calibration.py
@@ -21,8 +21,8 @@ class Calibration:
         self.width = int(config['general']['width'])
         self.height = int(config['general']['height'])
 
-        self.left_camera_id = config['general']['left_camera_id']
-        self.right_camera_id = config['general']['right_camera_id']
+        self.left_camera_id = int(config['general']['left_camera_id'])
+        self.right_camera_id = int(config['general']['right_camera_id'])
 
         self.capture_directory = capture_directory
         self.load_directory = load_directory
@@ -91,12 +91,7 @@ class Calibration:
         print('Calibration :: Computing...')
 
         
-        self.chessboard_size = float(self.chessboard_size)
-        self.chessboard_rows = int(self.chessboard_rows)
-        self.chessboard_cols = int(self.chessboard_cols)
-        self.width = int(self.width)
-        self.height = int(self.height)
-        calibrator = StereoCalibrator( self.chessboard_rows,  self.chessboard_cols,  self.chessboard_size, (self.width, self.height))
+        calibrator = StereoCalibrator(self.chessboard_rows, self.chessboard_cols, self.chessboard_size, (self.width, self.height))
 
         for i in range (0, 30, 1):
             if not os.path.exists(self.capture_directory + 'left/img' + str(i) + '.png'):

--- a/lib/calibration.py
+++ b/lib/calibration.py
@@ -13,13 +13,13 @@ from lib.helpers import open_capture
 # stereo cameras.
 class Calibration:
     def __init__(self, config, load_directory, capture_directory = '/tmp/stereo/'):
-        self.width = config['general']['width']
-        self.height = config['general']['height']
         self.config = config
 
-        self.chessboard_rows = config['calibration']['chessboard_rows']
-        self.chessboard_cols = config['calibration']['chessboard_cols']
-        self.chessboard_size = config['calibration']['chessboard_size']
+        self.chessboard_rows = int(config['calibration']['chessboard_rows'])
+        self.chessboard_cols = int(config['calibration']['chessboard_cols'])
+        self.chessboard_size = float(config['calibration']['chessboard_size'])
+        self.width = int(config['general']['width'])
+        self.height = int(config['general']['height'])
 
         self.left_camera_id = config['general']['left_camera_id']
         self.right_camera_id = config['general']['right_camera_id']
@@ -49,17 +49,41 @@ class Calibration:
         print('Waiting 5s...')
         time.sleep(5)
 
-        for i in range (0, 30, 1):
+        for i in range(0, 30, 1):
             print('Waiting 1s...')
             time.sleep(1)
 
             _, frame1 = leftCapture.read()
             _, frame2 = rightCapture.read()
 
+
             cv2.imwrite(self.capture_directory + 'left/img' + str(i) + '.png', frame1)
             cv2.imwrite(self.capture_directory + 'right/img' + str(i) + '.png', frame2)
 
-            print('Frame ' + str(i) + ' done')
+            # Try to find and draw chessboard corners for visual feedback
+            gray1 = cv2.cvtColor(frame1, cv2.COLOR_BGR2GRAY)
+            gray2 = cv2.cvtColor(frame2, cv2.COLOR_BGR2GRAY)
+
+            ret1, corners1 = cv2.findChessboardCorners(gray1, (self.chessboard_cols, self.chessboard_rows), None)
+            ret2, corners2 = cv2.findChessboardCorners(gray2, (self.chessboard_cols, self.chessboard_rows), None)
+
+            cv2.drawChessboardCorners(frame1, (self.chessboard_cols, self.chessboard_rows), corners1, ret1)
+            cv2.drawChessboardCorners(frame2, (self.chessboard_cols, self.chessboard_rows), corners2, ret2)
+
+            # Add status text
+            status = 'DETECTED' if (ret1 and ret2) else 'NOT FOUND'
+            color = (0, 255, 0) if (ret1 and ret2) else (0, 0, 255)
+            cv2.putText(frame1, status, (20, 40), cv2.FONT_HERSHEY_SIMPLEX, 1, color, 2)
+            cv2.putText(frame1, f'Captured: {i}/30', (20, 80), cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 255), 2)
+
+            cv2.imshow('Left', frame1)
+            cv2.imshow('Right', frame2)
+            cv2.waitKey(1)
+
+            print('Frame ' + str(i) + ' done - ' + status)
+
+        cv2.destroyAllWindows()
+
 
         print('Calibration :: Captured.')
 

--- a/lib/calibration.py
+++ b/lib/calibration.py
@@ -15,6 +15,7 @@ class Calibration:
     def __init__(self, config, load_directory, capture_directory = '/tmp/stereo/'):
         self.width = config['general']['width']
         self.height = config['general']['height']
+        self.config = config
 
         self.chessboard_rows = config['calibration']['chessboard_rows']
         self.chessboard_cols = config['calibration']['chessboard_cols']
@@ -42,8 +43,8 @@ class Calibration:
     def capture_images(self):
         print('Calibration :: Capturing frames...')
 
-        leftCapture = open_capture(self.left_camera_id, self.width, self.height)
-        rightCapture = open_capture(self.right_camera_id, self.width, self.height)
+        leftCapture = open_capture(self.left_camera_id, self.config)
+        rightCapture = open_capture(self.right_camera_id, self.config)
 
         print('Waiting 5s...')
         time.sleep(5)
@@ -65,6 +66,12 @@ class Calibration:
     def compute_calibration(self, show_results = False):
         print('Calibration :: Computing...')
 
+        
+        self.chessboard_size = float(self.chessboard_size)
+        self.chessboard_rows = int(self.chessboard_rows)
+        self.chessboard_cols = int(self.chessboard_cols)
+        self.width = int(self.width)
+        self.height = int(self.height)
         calibrator = StereoCalibrator( self.chessboard_rows,  self.chessboard_cols,  self.chessboard_size, (self.width, self.height))
 
         for i in range (0, 30, 1):
@@ -95,8 +102,8 @@ class Calibration:
         print('Calibration :: Exported to ' + self.load_directory)
 
         if show_results:
-            leftCapture = open_capture(self.left_camera_id, self.width, self.height)
-            rightCapture = open_capture(self.right_camera_id, self.width, self.height)
+            leftCapture = open_capture(self.left_camera_id, self.config)
+            rightCapture = open_capture(self.right_camera_id, self.config)
 
             cv2.namedWindow('Undistorted')
 

--- a/lib/camera.py
+++ b/lib/camera.py
@@ -1,11 +1,11 @@
 import cv2
-from threading import Thread
+from threading import Lock, Thread
 
 class Camera:
     def __init__(self, pipeline, id):
-        self.camera = cv2.VideoCapture(pipeline)
-        (self.grabbed, self.frame) = self.camera.read()
-
+        self.camera = cv2.VideoCapture(pipeline, cv2.CAP_GSTREAMER)
+        self.lock = Lock()
+        self.grabbed = False
         self.frame = None
         self.stopped = False
 
@@ -22,10 +22,17 @@ class Camera:
         self.thread.join()
 
     def read(self):
-        return (self.grabbed, self.frame)
+        with self.lock:
+            if not self.grabbed or self.frame is None or self.frame.size == 0:
+                return (False, None)
+
+            return (True, self.frame.copy())
 
     def thread(self):
         while self.stopped == False:
-            (self.grabbed, self.frame) = self.camera.read()
+            grabbed, frame = self.camera.read()
+            with self.lock:
+                self.grabbed = grabbed and frame is not None and frame.size > 0
+                self.frame = frame if self.grabbed else None
 
         self.camera.release()

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -34,6 +34,22 @@ def gstreamer_pipeline(
         )
     )
 
+def wait_for_valid_frames(captures, max_attempts=100):
+    for attempt in range(1, max_attempts + 1):
+        all_valid = True
+        for capture in captures:
+            grabbed, frame = capture.read()
+            if not grabbed or frame is None or frame.size == 0:
+                all_valid = False
+                break
+
+        if all_valid:
+            if attempt > 1:
+                print(f'Cameras ready after {attempt} frames')
+            return
+
+    raise Exception(f'Could not get valid frames from all cameras after {max_attempts} attempts')
+
 def open_capture(id, config):
     stream = gstreamer_pipeline(id, config)
     capture = Camera(stream, id)

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -23,19 +23,19 @@ def gstreamer_pipeline(
         "videoconvert ! "
         "video/x-raw, format=(string)BGR ! appsink"
         % (
-            id,
+            int(id),
             sensor_mode,
-            capture_width,
-            capture_height,
-            framerate,
+            int(capture_width),
+            int(capture_height),
+            int(framerate),
             flip_method,
-            display_width,
-            display_height,
+            int(display_width),
+            int(display_height),
         )
     )
 
-def open_capture(id, width, height):
-    stream = gstreamer_pipeline(id, width, height)
+def open_capture(id, config):
+    stream = gstreamer_pipeline(id, config)
     capture = Camera(stream, id)
 
     if not capture.isOpened():

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -9,9 +9,9 @@ def gstreamer_pipeline(
     sensor_mode=3,
     flip_method=0,
 ):
-    framerate = config['general']['framerate']
-    display_width = config['general']['width']
-    display_height = config['general']['height']
+    framerate = int(config['general']['framerate'])
+    display_width = int(config['general']['width'])
+    display_height = int(config['general']['height'])
 
     return (
         "nvarguscamerasrc sensor-id=%d sensor-mode=%d ! "
@@ -27,10 +27,10 @@ def gstreamer_pipeline(
             sensor_mode,
             int(capture_width),
             int(capture_height),
-            int(framerate),
+            framerate,
             flip_method,
-            int(display_width),
-            int(display_height),
+            display_width,
+            display_height,
         )
     )
 

--- a/lib/matchers/stereoBM.py
+++ b/lib/matchers/stereoBM.py
@@ -2,25 +2,25 @@ import cv2
 
 class StereoBMMatcher:
     def __init__(self, config):
-        self.width = config['general']['width']
-        self.height = config['general']['height']
+        self.width = int(config['general']['width'])
+        self.height = int(config['general']['height'])
 
-        downsample = config['general']['downsample_factor']
+        downsample = int(config['general']['downsample_factor'])
 
-        self.resize = (int(self.width / downsample), int(self.height / downsample))
+        self.resize = (self.width // downsample, self.height // downsample)
 
         # Apply configuration settings
         self.sbm = cv2.StereoBM_create(
-            numDisparities=config['stereobm']['num_disparities'],
-            blockSize=config['stereobm']['block_size']
+            numDisparities=int(config['stereobm']['num_disparities']),
+            blockSize=int(config['stereobm']['block_size'])
         )
         self.sbm.setPreFilterType(1)
-        self.sbm.setMinDisparity(config['stereobm']['min_disparity'])
-        self.sbm.setNumDisparities(config['stereobm']['num_disparities'])
-        self.sbm.setTextureThreshold(config['stereobm']['texture_threshold'])
-        self.sbm.setUniquenessRatio(config['stereobm']['uniqueness_ratio'])
-        self.sbm.setSpeckleRange(config['stereobm']['speckle_range'])
-        self.sbm.setSpeckleWindowSize(config['stereobm']['speckle_window'])
+        self.sbm.setMinDisparity(int(config['stereobm']['min_disparity']))
+        self.sbm.setNumDisparities(int(config['stereobm']['num_disparities']))
+        self.sbm.setTextureThreshold(int(config['stereobm']['texture_threshold']))
+        self.sbm.setUniquenessRatio(int(config['stereobm']['uniqueness_ratio']))
+        self.sbm.setSpeckleRange(int(config['stereobm']['speckle_range']))
+        self.sbm.setSpeckleWindowSize(int(config['stereobm']['speckle_window']))
 
     def process_pair(self, rectified_pair):
         left = cv2.resize(rectified_pair[0], self.resize)

--- a/lib/matchers/stereoSGBM.py
+++ b/lib/matchers/stereoSGBM.py
@@ -2,27 +2,27 @@ import cv2
 
 class StereoSGBMMatcher:
     def __init__(self, config):
-        self.width = config['general']['width']
-        self.height = config['general']['height']
+        self.width = int(config['general']['width'])
+        self.height = int(config['general']['height'])
 
-        downsample = config['general']['downsample_factor']
+        downsample = int(config['general']['downsample_factor'])
 
-        self.resize = (int(self.width / downsample), int(self.height / downsample))
+        self.resize = (self.width // downsample, self.height // downsample)
 
-        blockSize = config['stereosgbm']['block_size']
+        blockSize = int(config['stereosgbm']['block_size'])
 
         # Apply configuration settings
         self.sbm = cv2.StereoSGBM_create(
-            config['stereosgbm']['min_disparity'],
-            config['stereosgbm']['num_disparities'],
+            int(config['stereosgbm']['min_disparity']),
+            int(config['stereosgbm']['num_disparities']),
             blockSize,
-            config['stereosgbm']['p1_factor'] * blockSize * blockSize,
-            config['stereosgbm']['p2_factor'] * blockSize * blockSize,
-            config['stereosgbm']['disp_12_max_diff'],
-            config['stereosgbm']['pre_filter_cap'],
-            config['stereosgbm']['uniqueness_ratio'],
-            config['stereosgbm']['speckle_window'],
-            config['stereosgbm']['speckle_range'])
+            int(config['stereosgbm']['p1_factor']) * blockSize * blockSize,
+            int(config['stereosgbm']['p2_factor']) * blockSize * blockSize,
+            int(config['stereosgbm']['disp_12_max_diff']),
+            int(config['stereosgbm']['pre_filter_cap']),
+            int(config['stereosgbm']['uniqueness_ratio']),
+            int(config['stereosgbm']['speckle_window']),
+            int(config['stereosgbm']['speckle_range']))
 
     def process_pair(self, rectified_pair):
         left = cv2.resize(rectified_pair[0], self.resize)

--- a/lib/stereo.py
+++ b/lib/stereo.py
@@ -1,7 +1,7 @@
 import cv2
 import sys
 import numpy as np
-from lib.helpers import open_capture
+from lib.helpers import open_capture, wait_for_valid_frames
 
 import time
 
@@ -38,6 +38,7 @@ class StereoCapture:
     def produce_depth_map(self):
         self.leftCapture = open_capture(self.left_camera_id, self.config)
         self.rightCapture = open_capture(self.right_camera_id, self.config)
+        wait_for_valid_frames([self.leftCapture, self.rightCapture])
 
         cv2.namedWindow("Depth map")
 
@@ -50,7 +51,7 @@ class StereoCapture:
             left_grabbed, left_frame = self.leftCapture.read()
             right_grabbed, right_frame = self.rightCapture.read()
 
-            if left_grabbed and right_grabbed:
+            if left_grabbed and right_grabbed and left_frame is not None and right_frame is not None:
                 rectified_pair = self.rectify(left_frame, right_frame)
                 disparity = self.matcher.process_pair(rectified_pair)
 

--- a/lib/stereo.py
+++ b/lib/stereo.py
@@ -15,13 +15,13 @@ class StereoCapture:
         self.calibrator = calibrator
         self.stopped = False
 
-        self.width = config['general']['width']
-        self.height = config['general']['height']
+        self.width = int(config['general']['width'])
+        self.height = int(config['general']['height'])
 
-        self.left_camera_id = config['general']['left_camera_id']
-        self.right_camera_id = config['general']['right_camera_id']
+        self.left_camera_id = int(config['general']['left_camera_id'])
+        self.right_camera_id = int(config['general']['right_camera_id'])
 
-        self.show_rgb = config['general']['show_rgb_frame']
+        self.show_rgb = config.getboolean('general', 'show_rgb_frame')
 
         print(matcher)
 


### PR DESCRIPTION
This PR resolves a number of breaking changes that jetpack applied over the years.

1. Bump dependencies, especially `cudatoolkit` and `pytorch` which don't even have those versions available anymore. Resolves issue https://github.com/Matchstic/depthmapper/issues/1
1. Casting issues with `config` where python3 does not implicitly cast `config` to `int`s and `float`s - Resolves issue https://github.com/Matchstic/depthmapper/issues/2
1. Wait for cameras to warm up - Maybe this is just my particular camera, but I was getting errors about frames being empty and so forth. Ends up we just needed to "wait" a few milliseconds for `gstreamer_pipeline` to start returning non-empty frames.
1. Usability improvement - show calibratino frames in "real time" to assist user in positioning chess board correctly.